### PR TITLE
Allow _bare framework to build project without framework=arduino.

### DIFF
--- a/builder/frameworks/_bare.py
+++ b/builder/frameworks/_bare.py
@@ -1,0 +1,66 @@
+# Copyright 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Default flags for bare-metal programming (without any framework layers)
+#
+
+from SCons.Script import Import
+
+Import("env")
+
+machine_flags = [
+    "-mmcu=$BOARD_MCU",
+]
+
+env.Append(
+    ASFLAGS=machine_flags,
+    ASPPFLAGS=[
+        "-x", "assembler-with-cpp",
+    ],
+
+    CFLAGS=[
+        "-std=gnu11",
+        "-fno-fat-lto-objects"
+    ],
+
+    CCFLAGS=machine_flags + [
+        "-Os",  # optimize for size
+        "-Wall",  # show warnings
+        "-ffunction-sections",  # place each function in its own section
+        "-fdata-sections",
+        "-flto",
+    ],
+
+    CXXFLAGS=[
+        "-Wno-error=narrowing",
+        "-fno-exceptions",
+        "-fno-threadsafe-statics",
+        "-fpermissive",
+        "-std=gnu++11"
+    ],
+
+    CPPDEFINES=[
+        ("F_CPU", "$BOARD_F_CPU")
+    ],
+
+    LINKFLAGS=machine_flags + [
+        "-Os",
+        "-Wl,--gc-sections",
+        "-flto",
+        "-fuse-linker-plugin"
+    ],
+
+    LIBS=["m"]
+)

--- a/builder/main.py
+++ b/builder/main.py
@@ -140,6 +140,9 @@ env.Append(
 if env.get("PROGNAME", "program") == "program":
     env.Replace(PROGNAME="firmware")
 
+if not env.get("PIOFRAMEWORK"):
+    env.SConscript("frameworks/_bare.py", exports="env")
+
 #
 # Target: Build executable and linkable firmware
 #


### PR DESCRIPTION
This adds another builder script which is executed when no framework is selected. It allows compiling projects without the arduino framework.

See #7 for reasoning - this PR fixes it.